### PR TITLE
Dynamic logclean definition

### DIFF
--- a/examples/init.pp
+++ b/examples/init.pp
@@ -1,1 +1,5 @@
-include logclean
+class { 'logclean':
+  logconfig => [
+    '/var/log/something-*.log;30',
+  ]
+}

--- a/files/logclean.conf
+++ b/files/logclean.conf
@@ -1,1 +1,0 @@
-/data/logs/sunappserver/*.log;30

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,5 +1,5 @@
 #
-class logclean {
+class logclean($logconfig=undef) {
 
   file { '/etc/cron.daily/logclean':
     ensure  => present,
@@ -9,11 +9,8 @@ class logclean {
   }
 
   file { '/etc/logclean.conf':
-    ensure => present,
-    source => [
-                "puppet:///modules/logclean/logclean.conf.${::hostname}",
-                'puppet:///modules/logclean/logclean.conf',
-              ]
+    ensure  => present,
+    content => template('logclean/logclean.conf.erb'),
   }
 
   file { '/usr/local/scripts/logclean':

--- a/templates/logclean.conf.erb
+++ b/templates/logclean.conf.erb
@@ -1,0 +1,3 @@
+<% if @logconfig %>
+<% logconfig.each do |log| %><%= log%><%end%>
+<%end%>


### PR DESCRIPTION
Hosts using this module should be fixed on the master,
the $logconfig variable should be passed to the class.
Please refer to the example for more info.
